### PR TITLE
Add concurrency/multiprocessing to the packet sniff results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nfq-to-wol"
-version = "0.1.5"
+version = "0.2.0"
 description = "A daemon to check for packets to a certain host and send a WOL if needed"
 authors = ["Shaun Alexander <shaun@sierraalpha.co.nz>"]
 

--- a/templates/nfq-to-wol.yaml
+++ b/templates/nfq-to-wol.yaml
@@ -1,7 +1,7 @@
 # Example YAML config file for NFQ to WOL
 
 # Timeout for ping checks in seconds
-#ping_timeout: 1
+#ping-timeout: 1
 
 # List of hosts with their IP addresses and MAC addresses
 hosts:

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,7 +1,7 @@
 # Test YAML config file for NFQ to WOL
 
 # Used in testing
-ping_timeout: 22
+ping-timeout: 22
 
 # List of hosts with their IP addresses and MAC addresses
 hosts:


### PR DESCRIPTION
I was finding that scapy was not fast enough in real world workloads so here I implement a background processing in other threads to allow scapy to keep the buffer use to a minimum. Initial quick look was showing catastrophic results, total machine lockup when the network buffer filled up after around a day then all network requests failed and retried further loading the system till eventually this resulted in an unusable system. Hopefully my hunch to the root cause is correct and this feature fixes the issue.